### PR TITLE
feat: replace navbar with video game navigation

### DIFF
--- a/all-things-video-games/docusaurus.config.js
+++ b/all-things-video-games/docusaurus.config.js
@@ -89,13 +89,22 @@ const config = {
           src: 'img/logo.svg',
         },
         items: [
+          {to: '/', label: 'Home', position: 'left'},
           {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
+            type: 'dropdown',
+            label: 'Video Games',
             position: 'left',
-            label: 'Tutorial',
+            items: [
+              {to: '/docs/action-games', label: 'Action'},
+              {to: '/docs/adventure-games', label: 'Adventure'},
+              {to: '/docs/rpg-games', label: 'RPG'},
+              {to: '/docs/strategy-games', label: 'Strategy'},
+              {to: '/docs/sports-games', label: 'Sports'},
+            ],
           },
-          {to: '/blog', label: 'Blog', position: 'left'},
+          {to: '/docs/reviews', label: 'Reviews', position: 'left'},
+          {to: '/about', label: 'About Us', position: 'left'},
+          {to: '/contact', label: 'Contact Us', position: 'left'},
           {
             href: 'https://github.com/facebook/docusaurus',
             label: 'GitHub',


### PR DESCRIPTION
Switched out the old Tutorial/Blog navbar for proper gaming navigation. Now we have:

<img width="1845" height="977" alt="Screenshot 2026-02-13 132955" src="https://github.com/user-attachments/assets/de2f5761-f823-4a75-817f-aa4d04b7f369" />

closes #24 