### PR TITLE
Add scroll-to-top button that appears after scrolling

### DIFF
--- a/src/components/BackToTopButton.js
+++ b/src/components/BackToTopButton.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+
+const SCROLL_THRESHOLD = 300;
+
+export default function BackToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > SCROLL_THRESHOLD);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      className="backToTopButton"
+      onClick={scrollToTop}
+      aria-label="Back to top"
+    >
+      ↑ Top
+    </button>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,7 +18,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
+[data-theme="dark"] {
   --ifm-color-primary: #25c2a0;
   --ifm-color-primary-dark: #21af90;
   --ifm-color-primary-darker: #1fa588;
@@ -27,4 +27,23 @@
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+.backToTopButton {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1000;
+  border: 1px solid var(--ifm-color-primary-dark);
+  border-radius: var(--ifm-global-radius);
+  background-color: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.backToTopButton:hover {
+  background-color: var(--ifm-color-primary-dark);
 }

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import Layout from "@theme-original/Layout";
+import BackToTopButton from "@site/src/components/BackToTopButton";
+
+export default function LayoutWrapper(props) {
+  return (
+    <>
+      <Layout {...props} />
+      <BackToTopButton />
+    </>
+  );
+}


### PR DESCRIPTION
Adds a floating “Top” button that appears once the user scrolls down.
Clicking the button smoothly scrolls the page back to the top.
Integrates globally by wrapping the Docusaurus layout, so it works across pages.

closes #104 