### PR TITLE
style: Fix centering on home page

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -1,7 +1,7 @@
 .features {
   display: flex;
-  align-items: center;
-  padding: 2rem 0;
+  align-items: stretch;
+  padding: 5rem 0;
   width: 100%;
 }
 


### PR DESCRIPTION
Fixed the padding to center the 3 categories with icons on the home page.
Closes #114 