### PR TITLE
docs: remove all blog configuration and navbar references

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,22 +52,6 @@ const config = {
           editUrl:
             'https://github.com/NSCC-ITC-Winter2026-WEBD3030-700-MCa/All-things-Video-Games/tree/main/all-things-video-games',
         },
-
-        blog: {
-          showReadingTime: true,
-          feedOptions: {
-            type: ['rss', 'atom'],
-            xslt: true,
-          },
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/NSCC-ITC-Winter2026-WEBD3030-700-MCa/All-things-Video-Games/tree/main/all-things-video-games',
-          // Useful options to enforce blogging best practices
-          onInlineTags: 'warn',
-          onInlineAuthors: 'warn',
-          onUntruncatedBlogPosts: 'warn',
-        },
         theme: {
           customCss: './src/css/custom.css',
         },


### PR DESCRIPTION
## Description

Completely remove the blog plugin configuration from the classic preset, any blog-related navbar items, and any other blog mentions (tags, authors, feed, etc.) to eliminate all blog functionality.

## Changes

- `docusaurus.config.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `critical`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #103